### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``create_instance`` - Action which creates a new instance.

--- a/actions/create_instance.yaml
+++ b/actions/create_instance.yaml
@@ -51,4 +51,4 @@ parameters:
     type: string
     description: Ssh key to attach to this instance.
 
-runner_type: run-python
+runner_type: python-script

--- a/actions/create_keypair.yaml
+++ b/actions/create_keypair.yaml
@@ -12,4 +12,4 @@ parameters:
     type: integer
     description: Key length for the keypair. Must be a multiple of 256, and no smaller than 1024.
     default: 4096
-runner_type: run-python
+runner_type: python-script

--- a/actions/delete_keypair.yaml
+++ b/actions/delete_keypair.yaml
@@ -7,4 +7,4 @@ parameters:
     required: true
     type: string
     description: Name of the key pair.
-runner_type: run-python
+runner_type: python-script

--- a/actions/destroy_instance.yaml
+++ b/actions/destroy_instance.yaml
@@ -8,4 +8,4 @@ parameters:
     type: string
     description: Instance hostname to destroy (Softlayer hostname, so domain included)
 
-runner_type: run-python
+runner_type: python-script

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description : st2 content pack containing Softlayer integrations.
 keywords:
   - softlayer
   - cloud
-version : 0.2.0
+version : 0.3.0
 author : Itxaka Serrano Garcia
 email : itxakaserrano@gmail.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.