### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 1.0.1
+
+* Fixed CI errors
+* PyCrypto was deprecated and replaced with PyCryptodome
+* Apache removed the SOFTLAYER attribute from libcloud.compute.types in v3.8.0
+
 # 1.0.0
 
 * Drop Python 2.7 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description : st2 content pack containing Softlayer integrations.
 keywords:
   - softlayer
   - cloud
-version: 1.0.0
+version: 1.0.1
 author : Itxaka Serrano Garcia
 email : itxakaserrano@gmail.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-apache-libcloud
-pycrypto
+apache-libcloud==v3.7.0
+pycryptodome


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- PyCrypto was deprecated and replaced with PyCryptodome
    - https://github.com/pycrypto/pycrypto/issues/238
    - https://stackoverflow.com/a/50099842
- Apache removed the `SOFTLAYER` attribute from `libcloud.compute.types` in v3.8.0 (latest) so pinned it to v3.7.0
    - https://github.com/apache/libcloud/issues/2035
